### PR TITLE
Allow FreeBlocks to be installed system-wide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,19 @@ CC=gcc
 CFLAGS+=-Wall -O2 -mms-bitfields -std=c99
 LDFLAGS+=-lSDL -lSDL_ttf -lSDL_image -lSDL_mixer
 
+PREFIX=/usr/local
+BINDIR=$(PREFIX)/bin
+DATADIR=$(PREFIX)/share
+PKGDATADIR=$(DATADIR)/$(PROJNAME)
+APPDATADIR=$(DATADIR)/applications
+
+INSTALL=install
+INSTALLDIR=$(INSTALL) -d -m 0755
+INSTALLBIN=$(INSTALL) -c -m 0755 -s
+INSTALLDAT=$(INSTALL) -c -m 0644
+
+#CFLAGS+=-DPKGDATADIR=\"$(PKGDATADIR)\"
+
 all: $(BUILDDIR) $(SOURCES) $(PROJNAME)
 
 $(BUILDDIR):
@@ -33,3 +46,17 @@ clean:
 	rm -rf $(BUILDDIR)/ $(PROJNAME)
 	@rm ./.depend
 
+install:
+	$(INSTALLDIR) $(DESTDIR)$(BINDIR)
+	$(INSTALLBIN) $(PROJNAME) $(DESTDIR)$(BINDIR)
+	$(INSTALLDIR) $(DESTDIR)$(PKGDATADIR)/res/fonts
+	$(INSTALLDAT) res/fonts/*.ttf $(DESTDIR)$(PKGDATADIR)/res/fonts
+	$(INSTALLDIR) $(DESTDIR)$(PKGDATADIR)/res/graphics
+	$(INSTALLDAT) res/graphics/*.png $(DESTDIR)$(PKGDATADIR)/res/graphics
+	$(INSTALLDIR) $(DESTDIR)$(PKGDATADIR)/res/sounds
+	$(INSTALLDAT) res/sounds/*.wav $(DESTDIR)$(PKGDATADIR)/res/sounds
+	$(INSTALLDAT) res/sounds/*.ogg $(DESTDIR)$(PKGDATADIR)/res/sounds
+	$(INSTALLDIR) $(DESTDIR)$(APPDATADIR)
+	$(INSTALLDAT) $(PROJNAME).desktop $(DESTDIR)$(APPDATADIR)
+
+.PHONY: install clean

--- a/freeblocks.desktop
+++ b/freeblocks.desktop
@@ -1,0 +1,22 @@
+[Desktop Entry]
+Version=1.0
+
+Type=Application
+
+Name=FreeBlocks
+Comment=A puzzle game similar to Tetris Attack
+Comment[da]=Et puslespil ligner Tetris Attack
+Comment[de]=Ein Rätselspiel ähnlich wie Tetris Attack
+Comment[es]=Un juego de puzzle similar al Tetris Attack
+Comment[fr]=Un puzzle similaire à Tetris Attack
+Comment[it]=Un giocho di puzzle simile a Tetris Attack
+Comment[nb]=Et puslespill som ligner på Tetris Attack
+Comment[nl]=Een puzzel spel vergelijkbaar met Tetris Attack
+Comment[sv]=Ett pusselspel som liknar Tetris Attack
+Icon=
+
+Categories=SDL;Game;BlocksGame;
+
+Exec=freeblocks
+Terminal=false
+StartupNotify=false

--- a/src/sys.c
+++ b/src/sys.c
@@ -95,12 +95,12 @@ bool sysInit() {
 
 bool sysLoadFiles() {
     // font
-    font = TTF_OpenFont("./res/fonts/Alegreya-Regular.ttf",20);
+    font = TTF_OpenFont(PKGDATADIR "/fonts/Alegreya-Regular.ttf",20);
     if(!font) return false;
     else TTF_SetFontHinting(font, TTF_HINTING_LIGHT);
 
     // graphics
-    surface_blocks = IMG_Load("./res/graphics/blocks.png");
+    surface_blocks = IMG_Load(PKGDATADIR "/graphics/blocks.png");
     if (!surface_blocks) return false;
     else {
         SDL_Surface *cleanup = surface_blocks;
@@ -108,7 +108,7 @@ bool sysLoadFiles() {
         SDL_FreeSurface(cleanup);
     }
 
-    surface_clear = IMG_Load("./res/graphics/clear.png");
+    surface_clear = IMG_Load(PKGDATADIR "/graphics/clear.png");
     if (!surface_clear) return false;
     else {
         SDL_Surface *cleanup = surface_clear;
@@ -116,7 +116,7 @@ bool sysLoadFiles() {
         SDL_FreeSurface(cleanup);
     }
 
-    surface_cursor = IMG_Load("./res/graphics/cursor.png");
+    surface_cursor = IMG_Load(PKGDATADIR "/graphics/cursor.png");
     if (!surface_cursor) return false;
     else {
         SDL_Surface *cleanup = surface_blocks;
@@ -124,7 +124,7 @@ bool sysLoadFiles() {
         SDL_FreeSurface(cleanup);
     }
 
-    surface_bar = IMG_Load("./res/graphics/bar.png");
+    surface_bar = IMG_Load(PKGDATADIR "/graphics/bar.png");
     if (!surface_bar) return false;
     else {
         SDL_Surface *cleanup = surface_bar;
@@ -132,7 +132,7 @@ bool sysLoadFiles() {
         SDL_FreeSurface(cleanup);
     }
 
-    surface_bar_inactive = IMG_Load("./res/graphics/bar_inactive.png");
+    surface_bar_inactive = IMG_Load(PKGDATADIR "/graphics/bar_inactive.png");
     if (!surface_bar_inactive) return false;
     else {
         SDL_Surface *cleanup = surface_bar_inactive;
@@ -140,7 +140,7 @@ bool sysLoadFiles() {
         SDL_FreeSurface(cleanup);
     }
 
-    surface_background = IMG_Load("./res/graphics/background.png");
+    surface_background = IMG_Load(PKGDATADIR "/graphics/background.png");
     if (!surface_background) return false;
     else {
         SDL_Surface *cleanup = surface_background;
@@ -148,7 +148,7 @@ bool sysLoadFiles() {
         SDL_FreeSurface(cleanup);
     }
 
-    surface_title = IMG_Load("./res/graphics/title.png");
+    surface_title = IMG_Load(PKGDATADIR "/graphics/title.png");
     if (!surface_title) return false;
     else {
         SDL_Surface *cleanup = surface_title;
@@ -156,7 +156,7 @@ bool sysLoadFiles() {
         SDL_FreeSurface(cleanup);
     }
 
-    surface_highscores = IMG_Load("./res/graphics/highscores.png");
+    surface_highscores = IMG_Load(PKGDATADIR "/graphics/highscores.png");
     if (!surface_highscores) return false;
     else {
         SDL_Surface *cleanup = surface_highscores;
@@ -165,17 +165,17 @@ bool sysLoadFiles() {
     }
 
     // background music
-    music = Mix_LoadMUS("res/sounds/music.ogg");
+    music = Mix_LoadMUS(PKGDATADIR "/sounds/music.ogg");
     if (!music) return false;
 
     // sound effects
-    sound_menu = Mix_LoadWAV("res/sounds/menu.wav");
+    sound_menu = Mix_LoadWAV(PKGDATADIR "/sounds/menu.wav");
     if (!sound_menu) return false;
 
-    sound_switch = Mix_LoadWAV("res/sounds/switch.wav");
+    sound_switch = Mix_LoadWAV(PKGDATADIR "/sounds/switch.wav");
     if (!sound_switch) return false;
 
-    sound_match = Mix_LoadWAV("res/sounds/match.wav");
+    sound_match = Mix_LoadWAV(PKGDATADIR "/sounds/match.wav");
     if (!sound_match) return false;
 
     return true;

--- a/src/sys.h
+++ b/src/sys.h
@@ -37,6 +37,10 @@ typedef enum { false = 0, true = 1 } bool;
 #define OPTIONS_SOUND 2
 #define OPTIONS_MUSIC 3
 
+#ifndef PKGDATADIR
+#define PKGDATADIR "./res"
+#endif
+
 SDL_Surface* screen;
 TTF_Font* font;
 


### PR DESCRIPTION
Allow FreeBlocks to be installed system-wide. This makes it also trivial to build a package.

```
modified:   Makefile
new file:   freeblocks.desktop
modified:   src/sys.c
modified:   src/sys.h
```
