### PR TITLE
Allow different move commands under cooldown

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -241,36 +241,41 @@ void gameLogic() {
 void gameMove() {
     cursor_moving = false;
     if (cursor_y < 1) cursor_y = 1;
-    if (action_cooldown > 0) return;
+    if (action_move == action_last_move && action_cooldown > 0) return;
 
-    if (action_left && cursor_x > 0) {
-        cursor_x--;
-        cursor_moving = true;
-        if (action_right || action_up || action_down)
+    switch (action_move) {
+    case ACTION_LEFT:
+        if (cursor_x > 0) {
+            cursor_x--;
+            cursor_moving = true;
             cursor_timer = -1;
-    }
-    if (action_right && cursor_x < COLS-2) {
-        cursor_x++;
-        cursor_moving = true;
-        if (action_left || action_up || action_down)
+        }
+        break;
+    case ACTION_RIGHT:
+        if (cursor_x < COLS - 2) {
+            cursor_x++;
+            cursor_moving = true;
             cursor_timer = -1;
-    }
-    if (action_up && cursor_y > 1) {
-        cursor_y--;
-        cursor_moving = true;
-        if (action_left || action_right || action_down)
+        }
+        break;
+    case ACTION_UP:
+        if (cursor_y > 1) {
+            cursor_y--;
+            cursor_moving = true;
             cursor_timer = -1;
-    }
-    if (action_down && cursor_y < ROWS-2) {
-        cursor_y++;
-        cursor_moving = true;
-        if (action_left || action_right || action_up)
+        }
+        break;
+    case ACTION_DOWN:
+        if (cursor_y < ROWS - 2) {
+            cursor_y++;
+            cursor_moving = true;
             cursor_timer = -1;
+        }
+        break;
     }
 
     if (cursor_moving) {
-        if (!(action_left && action_right) && !(action_up && action_down))
-            Mix_PlayChannel(-1,sound_switch,0);
+        Mix_PlayChannel(-1,sound_switch,0);
 
         if (cursor_timer == -1)
             cursor_timer = FPS/5;
@@ -282,6 +287,8 @@ void gameMove() {
             action_cooldown = ACTION_COOLDOWN/2;
         else
             action_cooldown = ACTION_COOLDOWN;
+
+        action_last_move = action_move;
     }
     else {
         cursor_timer = -1;

--- a/src/menu.c
+++ b/src/menu.c
@@ -193,22 +193,20 @@ int menuLogic() {
             action_switch = false;
             Mix_PlayChannel(-1,sound_menu,0);
             return menu_option;
-        } else if (action_up && action_cooldown == 0 && menu_option > 0) {
+        } else if (action_move == ACTION_UP && action_cooldown == 0 && menu_option > 0) {
             menu_option--;
             action_cooldown = ACTION_COOLDOWN;
             Mix_PlayChannel(-1,sound_switch,0);
-        } else if (action_down && action_cooldown == 0 && menu_option < menu_size-1) {
+        } else if (action_move == ACTION_DOWN && action_cooldown == 0 && menu_option < menu_size-1) {
             menu_option++;
             action_cooldown = ACTION_COOLDOWN;
             Mix_PlayChannel(-1,sound_switch,0);
-        }
-        else if (action_left && action_cooldown == 0) {
+        } else if (action_move == ACTION_LEFT && action_cooldown == 0) {
             if (menuItemDecreaseVal(menu_option)) {
                 Mix_PlayChannel(-1,sound_switch,0);
             }
             action_cooldown = ACTION_COOLDOWN;
-        }
-        else if (action_right && action_cooldown == 0) {
+        } else if (action_move == ACTION_RIGHT && action_cooldown == 0) {
             if (menuItemIncreaseVal(menu_option)) {
                 Mix_PlayChannel(-1,sound_switch,0);
             }

--- a/src/sys.c
+++ b/src/sys.c
@@ -255,13 +255,13 @@ void sysInput() {
     while(SDL_PollEvent(&event)) {
         if(event.type == SDL_KEYDOWN) {
             if(event.key.keysym.sym == SDLK_LEFT)
-                action_left = true;
+                action_move = ACTION_LEFT;
             if(event.key.keysym.sym == SDLK_RIGHT)
-                action_right = true;
+                action_move = ACTION_RIGHT;
             if(event.key.keysym.sym == SDLK_UP)
-                action_up = true;
+                action_move = ACTION_UP;
             if(event.key.keysym.sym == SDLK_DOWN)
-                action_down = true;
+                action_move = ACTION_DOWN;
             if(event.key.keysym.sym == KEY_SWITCH)
                 action_switch = true;
             if(event.key.keysym.sym == KEY_BUMP)
@@ -273,14 +273,13 @@ void sysInput() {
         }
 
         else if(event.type == SDL_KEYUP) {
-            if(event.key.keysym.sym == SDLK_LEFT)
-                action_left = false;
-            if(event.key.keysym.sym == SDLK_RIGHT)
-                action_right = false;
-            if(event.key.keysym.sym == SDLK_UP)
-                action_up = false;
-            if(event.key.keysym.sym == SDLK_DOWN)
-                action_down = false;
+            if(event.key.keysym.sym == SDLK_LEFT && action_move == ACTION_LEFT ||
+               event.key.keysym.sym == SDLK_RIGHT && action_move == ACTION_RIGHT ||
+               event.key.keysym.sym == SDLK_UP && action_move == ACTION_UP ||
+               event.key.keysym.sym == SDLK_DOWN && action_move == ACTION_DOWN) {
+                action_move = ACTION_NONE;
+                action_last_move = ACTION_NONE;
+            }
             if(event.key.keysym.sym == KEY_SWITCH)
                 action_switch = false;
             if(event.key.keysym.sym == KEY_BUMP)

--- a/src/sys.h
+++ b/src/sys.h
@@ -98,10 +98,11 @@ int cursor_x;
 int cursor_y;
 
 int action_cooldown;
-bool action_left;
-bool action_right;
-bool action_up;
-bool action_down;
+typedef enum {
+    ACTION_NONE, ACTION_LEFT, ACTION_RIGHT, ACTION_UP, ACTION_DOWN
+}ActionMove;
+ActionMove action_move;
+ActionMove action_last_move;
 bool action_switch;
 bool action_bump;
 bool action_pause;


### PR DESCRIPTION
Previously, move commands were affected by the
action_cooldown - only one move command was
allowed per cooldown period. Now move
commands are allowed as long as the move is
different from the last one.

![control](https://cloud.githubusercontent.com/assets/1083215/6199216/672e31be-b48a-11e4-8157-828ca15f8cd7.gif)
