### PR TITLE
Allow switching blocks when blocks moving

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -78,7 +78,6 @@ bool blockCompare(int i, int j, int k, int l) {
 bool blockAnimate() {
     int i,j;
     bool anim = false;
-    moving_blocks = false;
 
     for (i=0;i<ROWS;i++) {
         for (j=0;j<COLS;j++) {
@@ -94,23 +93,19 @@ bool blockAnimate() {
             // move blocks
             if (blocks[i][j].dest_x < blocks[i][j].x) {
                 blocks[i][j].x -= BLOCK_MOVE_SPEED;
-                moving_blocks = true;
                 anim = true;
             }
             else if (blocks[i][j].dest_x > blocks[i][j].x) {
                 blocks[i][j].x += BLOCK_MOVE_SPEED;
-                moving_blocks = true;
                 anim = true;
             }
 
             if (blocks[i][j].dest_y < blocks[i][j].y) {
                 blocks[i][j].y -= BLOCK_MOVE_SPEED;
-                moving_blocks = true;
                 anim = true;
             }
             else if (blocks[i][j].dest_y > blocks[i][j].y) {
                 blocks[i][j].y += BLOCK_MOVE_SPEED;
-                moving_blocks = true;
                 anim = true;
             }
         }
@@ -130,7 +125,6 @@ void blockInitAll() {
     speed = speed_init;
     speed_timer = SPEED_TIME;
     game_over_timer = 0;
-    moving_blocks = false;
 
     for(i=0;i<ROWS;i++) {
         for(j=0;j<COLS;j++) {
@@ -311,6 +305,5 @@ bool blockAddLayer() {
 }
 
 void blockSwitchCursor() {
-    if (moving_blocks == false)
-        blockSwitch(cursor_y, cursor_x, cursor_y, cursor_x+1, true);
+    blockSwitch(cursor_y, cursor_x, cursor_y, cursor_x+1, true);
 }

--- a/src/block.h
+++ b/src/block.h
@@ -59,7 +59,6 @@ int speed;
 int speed_init;
 int speed_timer;
 int game_over_timer;
-int moving_blocks;
 
 void blockSet(int i, int j, bool alive, int color);
 void blockClear(int i, int j);


### PR DESCRIPTION
Not allowing block switching when blocks moving causes a large delay when blocks are falling many layers. Removing this limitation means that player control is consistent regardless of what's happening in the game.

Demonstration with slowed block speed:
![swap](https://cloud.githubusercontent.com/assets/1083215/6240694/0b846d22-b766-11e4-8461-e73316c11ff6.gif)
