### PR TITLE
Fix last row blocks not clearing after match

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -219,7 +219,7 @@ void blockMatch() {
 
     if (!animating) {
         // now, clear all the matches
-        for (i=0;i<ROWS-1;i++) {
+        for (i=0;i<ROWS-DISABLED_ROWS;i++) {
             for(j=0;j<COLS;j++) {
                 if (blocks[i][j].matched) {
                     blockClear(i,j);


### PR DESCRIPTION
When DISABLED_ROWS set to 0 and bottom row matched,
blocks need to be cleared otherwise their matched flag will
always be true, preventing block switches.